### PR TITLE
Fix desktop icon on Linux

### DIFF
--- a/haven-desktop-app/forge.config.js
+++ b/haven-desktop-app/forge.config.js
@@ -132,7 +132,11 @@ module.exports = {
     {
       name: "@electron-forge/maker-deb",
       platforms: ["linux"],
-      config: {name:"haven", productName:"haven"},
+      config: {
+        name: "haven",
+        productName: "haven",
+        icon: "./icons/icon.png",
+      },
     },
   ],
 


### PR DESCRIPTION
Fixes https://github.com/haven-protocol-org/haven-web-app/issues/36

The solution was pretty simple, it was just add the icon config on the `.deb` build.