### PR TITLE
temporarily remove onboarding modal

### DIFF
--- a/client/src/platforms/desktop/components/modalContainer/index.tsx
+++ b/client/src/platforms/desktop/components/modalContainer/index.tsx
@@ -25,8 +25,8 @@ class ModalContainer extends React.Component<any, any> {
         return <QRCodeModal />;
       case MODAL_TYPE.ShowAddressModal:
         return <ManageAddressModal />;
-      case MODAL_TYPE.LoginOnboarding:
-        return <LoginOnboardingModal />;
+//      case MODAL_TYPE.LoginOnboarding:
+//        return <LoginOnboardingModal />;
       case MODAL_TYPE.RescanBC:
         return <RescanBCMModal />;
     }

--- a/client/src/platforms/web/routes/public/index.js
+++ b/client/src/platforms/web/routes/public/index.js
@@ -14,11 +14,12 @@ import { logM } from "utility/utility";
 const onboardingVersion = 2;
 class PublicRoutes extends Component {
   componentDidMount() {
-
+/*
     if (localStorage.getItem("onboard") !== onboardingVersion.toString() && isWeb() ) {
       this.props.showModal(MODAL_TYPE.LoginOnboarding);
       localStorage.setItem("onboard",onboardingVersion);
     }
+*/
   }
 
   render() {


### PR DESCRIPTION
The onboarding overlay has incorrect info about conversions and BTC. This is a simple temporary removal so that it can be re-instated with new messaging when appropriate