### PR TITLE
Force Mac builds to run on macos-13 (x86)

### DIFF
--- a/.github/workflows/desktop.build.yml
+++ b/.github/workflows/desktop.build.yml
@@ -21,7 +21,7 @@ jobs:
         system:
           - os: "windows-latest"
             path: "squirrel.windows/x64/"
-          - os: "macOS-latest"
+          - os: "macos-13"
             path: ""
           - os: ubuntu-latest
             path: "deb/x64/"

--- a/sh/make.sh
+++ b/sh/make.sh
@@ -4,7 +4,7 @@
 export HAVEN_DESKTOP_DEVELOPMENT=false
 export NODE_INSTALLER=npm
 
-if [ "$ACTION_OS" == "macOS-latest" ]
+if [ "$ACTION_OS" == "macos-13" ]
 then
     npm run make --prefix haven-desktop-app -- --arch="arm64,x64" 
 else 


### PR DESCRIPTION
GitHub recently changed macos-latest to point to macos-14 (M1) runners, causing builds to fail due to the unavailability of Node 14 on arm64.

Eventually, dependencies will need to be updated to allow a more recent version of Node. For now, specifying macos-13 and updating the make script accordingly will do.

Note that this will change the build output filenames.